### PR TITLE
Apply permissions from external file attributes after extraction

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -5,12 +5,15 @@ module.exports = Extract;
 var Parse = require("../unzip").Parse;
 var Writer = require("fstream").Writer;
 var Writable = require('stream').Writable;
+var fs = require('fs');
 var path = require('path');
 var inherits = require('util').inherits;
 
 if (!Writable) {
   Writable = require('readable-stream/writable');
 }
+
+var S_IFREG = 0x8000;     // #define S_IFREG  0100000  /* regular file */
 
 inherits(Extract, Writable);
 
@@ -27,6 +30,15 @@ function Extract (opts) {
   this._parser.on('error', function(err) {
     self.emit('error', err);
   });
+  var externalFileAttributes = [];
+  this._parser.on('metadata', function(e) {
+    if (e.type === 'centralDirectoryFileHeader') {
+      externalFileAttributes.push({
+        path: e.path,
+        mode: e.mode,
+      });
+    }
+  });
   this.on('finish', function() {
     self._parser.end();
   });
@@ -39,6 +51,25 @@ function Extract (opts) {
     self.emit('error', err);
   });
   writer.on('close', function() {
+    var dirPath = self._opts && self._opts.path;
+    if (dirPath) {
+      externalFileAttributes.forEach(function(attr) {
+        // Apply the permissions from the original "externalFileAttributes".
+        if (attr.mode & S_IFREG) {
+          var mode = (attr.mode & 0x1ff);
+          var filePath = path.join(dirPath, attr.path);
+          if (self._opts.verbose) {
+            console.log('Applying mode: 0' + mode.toString(8) + " to file " + filePath);
+          }
+          fs.chmod(filePath, mode, function(err) {
+            if (err) {
+              console.error('Unable to apply mode: 0' + mode.toString(8) + " to file " + filePath);
+            }
+          });
+        }
+
+      });
+    }
     self.emit('close')
   });
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -251,6 +251,12 @@ Parse.prototype._readCentralDirectoryFileHeader = function () {
       }
       fileName = fileName.toString('utf8');
 
+      self.emit('metadata', {
+        type: 'centralDirectoryFileHeader',
+        path: fileName,
+        mode: vars.externalFileAttributes >>> 16
+      });
+
       self._pullStream.pull(vars.extraFieldLength, function (err, extraField) {
         if (err) {
           return self.emit('error', err);


### PR DESCRIPTION
With guidance from the creator of the original package and the preliminary approach discussed in https://github.com/EvanOxfeld/node-unzip/pull/13, resolves the original issue https://github.com/EvanOxfeld/node-unzip/issues/6

Fixes https://github.com/Intermodalics/pickit/issues/4616